### PR TITLE
feat: integrate Tailwind tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
   "devDependencies": {
     "electron": "^35.1.2",
     "electron-builder": "^24.11.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.17"
   },
   "dependencies": {
     "@electron/remote": "^2.1.2",

--- a/style.css
+++ b/style.css
@@ -1,46 +1,22 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 /* Combined Stylesheet: Hierarchy Visuals & Panel Fix */
 
-:root {
-    --sidebar-bg: #1f1f23;
-    --sidebar-item-hover: rgba(135, 206, 250, 0.1);
-    --sidebar-item-selected: rgba(135, 206, 250, 0.2);
-    --sidebar-item-selected-border: var(--baby-blue);
-    --button-primary-bg: var(--baby-blue);
-    --button-primary-hover-bg: var(--baby-blue-darker);
-    --button-text-dark: #111;
-    --separator-color: #3a3a3d;
-    --scroll-padding: 10px;
-    --baby-blue: #87CEFA;
-    --baby-blue-darker: #6495ED;
-    --bg-very-dark: #0e0e10;
-    --bg-dark-grey: #18181b;
-    --text-off-white: #efeff1;
-    --text-grey: #adadb8;
-    --text-dark-grey: #888;
-    --border-color: #444;
-    --input-bg: #3a3a3d;
-    --user-green: #7FFFD4;
-    --light-cyan: #e0ffff;
-
-    /* New Size Variables */
-    --primary-icon-size: 38px;
-    --primary-item-padding: 8px 10px;
-    --primary-font-size: 0.95em;
-    --display-highlight: rgba(255, 165, 0, 0.6);
-}
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
-body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background-color: var(--bg-very-dark); color: var(--text-off-white); height: 100vh; overflow: hidden; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background-color: theme('colors.bg-very-dark'); color: theme('colors.text-off-white'); height: 100vh; overflow: hidden; }
 
-.app-container { display: grid; grid-template-columns: minmax(50px, 260px) 1fr minmax(50px, 340px); grid-template-rows: 1fr; height: 100vh; background-color: var(--bg-dark-grey); gap: 1px; background-color: var(--border-color); transition: grid-template-columns 0.3s ease-in-out; }
+.app-container { display: grid; grid-template-columns: minmax(50px, 260px) 1fr minmax(50px, 340px); grid-template-rows: 1fr; height: 100vh; background-color: theme('colors.bg-dark-grey'); gap: 1px; background-color: theme('colors.border'); transition: grid-template-columns 0.3s ease-in-out; }
 .app-container.collapsed { grid-template-columns: 50px 1fr minmax(50px, 340px); }
 .app-container.chat-collapsed { grid-template-columns: minmax(50px, 260px) 1fr 50px; }
 .app-container.collapsed.chat-collapsed { grid-template-columns: 50px 1fr 50px; }
 
 /* --- Left Sidebar --- */
 #left-sidebar {
-    background-color: var(--sidebar-bg);
+    background-color: theme('colors.sidebar-bg');
     width: 260px;
     padding: 0;
     transition: width 0.3s ease-in-out, transform 0.6s ease;
@@ -54,8 +30,8 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helve
 }
 #left-sidebar.collapsed { width: 50px; padding: 0; }
 #left-sidebar.collapsed #app-title { display: none; }
-#persona-section { padding: 10px 10px 0 10px; display: flex; flex-direction: column; padding-bottom: 10px; border-bottom: 1px solid var(--separator-color); }
-#persona-select { width: 100%; margin-bottom: 5px; padding: 4px; background-color: var(--bg-dark-grey); color: var(--text-off-white); border: 1px solid var(--border-color); border-radius: 4px; }
+#persona-section { padding: 10px 10px 0 10px; display: flex; flex-direction: column; padding-bottom: 10px; border-bottom: 1px solid theme('colors.separator'); }
+#persona-select { width: 100%; margin-bottom: 5px; padding: 4px; background-color: theme('colors.bg-dark-grey'); color: theme('colors.text-off-white'); border: 1px solid theme('colors.border'); border-radius: theme('borderRadius.sm'); }
 #persona-preview { text-align: center; padding-top: 10px; position: relative; }
 #favorite-star-overlay {
     position: absolute;
@@ -67,7 +43,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helve
     height: auto;
     object-fit: contain;
     display: block;
-    border: 2px solid var(--border-color);
+    border: 2px solid theme('colors.border');
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.7);
 }
 #persona-preview-image {
@@ -76,62 +52,62 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helve
     object-fit: contain;
     display: none;
 }
-#left-sidebar h2 { font-size: 0.75em; font-weight: 600; color: var(--text-grey); text-transform: uppercase; letter-spacing: 0.8px; padding: 10px 0 5px 5px; margin: 10px 0 5px 0; border: none; flex-shrink: 0; }
-#create-deck, #create-slide { width: 100%; padding: 6px 12px; margin-bottom: 10px; background-color: var(--button-primary-bg); color: var(--button-text-dark); border: none; border-radius: 5px; cursor: pointer; font-size: 0.85em; font-weight: 600; text-align: center; transition: background-color 0.2s ease, opacity 0.2s ease; flex-shrink: 0; }
-#create-deck:hover, #create-slide:hover { background-color: var(--button-primary-hover-bg); opacity: 0.9; }
+#left-sidebar h2 { font-size: 0.75em; font-weight: 600; color: theme('colors.text-grey'); text-transform: uppercase; letter-spacing: 0.8px; padding: 10px 0 5px 5px; margin: 10px 0 5px 0; border: none; flex-shrink: 0; }
+#create-deck, #create-slide { width: 100%; padding: 6px 12px; margin-bottom: 10px; background-color: theme('colors.baby-blue'); color: theme('colors.button-text-dark'); border: none; border-radius: theme('borderRadius.md'); cursor: pointer; font-size: 0.85em; font-weight: 600; text-align: center; transition: background-color 0.2s ease, opacity 0.2s ease; flex-shrink: 0; }
+#create-deck:hover, #create-slide:hover { background-color: theme('colors.baby-blue-darker'); opacity: 0.9; }
 #deck-controls { margin-bottom: 10px; padding: 5px 0; flex-shrink: 0; }
-#deck-dropdown { width: 100%; padding: 6px 8px; background-color: var(--input-bg); color: var(--text-off-white); border: 1px solid var(--border-color); border-radius: 5px; font-size: 0.85em; -webkit-appearance: none; appearance: none; }
+#deck-dropdown { width: 100%; padding: 6px 8px; background-color: theme('colors.input-bg'); color: theme('colors.text-off-white'); border: 1px solid theme('colors.border'); border-radius: theme('borderRadius.md'); font-size: 0.85em; -webkit-appearance: none; appearance: none; }
 
 /* --- Persona List Hierarchy Styles --- */
 .persona-list-container { list-style: none; padding: 0; margin: 0; flex-grow: 1; min-height: 0; }
 #persona-list-container { display: block; }
-.loading-personas { padding: 15px; text-align: center; color: var(--text-grey); font-style: italic; }
+.loading-personas { padding: 15px; text-align: center; color: theme('colors.text-grey'); font-style: italic; }
 
-.persona-item { display: flex; align-items: center; margin-bottom: 3px; cursor: pointer; border-radius: 5px; transition: background-color 0.15s ease, border-left-color 0.15s ease; overflow: hidden; border-left: 3px solid transparent; }
-.favorite-star { margin-left: auto; color: var(--text-grey); font-size: 1.1rem; cursor: pointer; }
+.persona-item { display: flex; align-items: center; margin-bottom: 3px; cursor: pointer; border-radius: theme('borderRadius.md'); transition: background-color 0.15s ease, border-left-color 0.15s ease; overflow: hidden; border-left: 3px solid transparent; }
+.favorite-star { margin-left: auto; color: theme('colors.text-grey'); font-size: 1.1rem; cursor: pointer; }
 .favorite-star.active { color: gold; }
-.persona-item:hover { background-color: var(--sidebar-item-hover); }
+.persona-item:hover { background-color: theme('colors.sidebar-item-hover'); }
 .persona-name { flex-grow: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: 1.4; }
 
 /* Primary Persona Item Styling */
 .persona-item.primary-persona {
-    padding: var(--primary-item-padding);
+    padding: theme('spacing.primary-item-y') theme('spacing.primary-item-x');
 }
 .persona-item.primary-persona .persona-icon {
-    width: var(--primary-icon-size);
-    height: var(--primary-icon-size);
+    width: theme('spacing.primary-icon');
+    height: theme('spacing.primary-icon');
     margin-right: 12px;
 }
 .persona-item.primary-persona .persona-name {
     font-weight: 600;
-    font-size: var(--primary-font-size);
+    font-size: theme('fontSize.primary');
 }
-.persona-item.primary-persona.selected { background-color: var(--sidebar-item-selected); border-left-color: var(--sidebar-item-selected-border); }
+.persona-item.primary-persona.selected { background-color: theme('colors.sidebar-item-selected'); border-left-color: theme('colors.baby-blue'); }
 
 
 
 /* Deck List */
 .deck-list { list-style: none; padding: 0; margin: 0; flex-grow: 1; min-height: 0; }
 #deck-list { display: none; }
-.deck-item { display: flex; align-items: center; padding: 7px 8px; margin-bottom: 3px; cursor: pointer; border-radius: 5px; transition: background-color 0.15s ease; overflow: hidden; border-left: 3px solid transparent; }
-.deck-item:hover { background-color: var(--sidebar-item-hover); }
-.deck-item.selected { background-color: var(--sidebar-item-selected); border-left: 3px solid var(--sidebar-item-selected-border); }
-.slide-icon { width: 32px; height: 32px; border-radius: 4px; object-fit: cover; margin-right: 10px; border: 1px solid var(--border-color); flex-shrink: 0; background-color: #444; }
-.slide-name { flex-grow: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-size: 0.9em; color: var(--text-off-white); line-height: 1.4; }
-button.deck-save-btn { margin-left: 5px; background: none; border: none; color: var(--text-off-white); cursor: pointer; }
+.deck-item { display: flex; align-items: center; padding: 7px 8px; margin-bottom: 3px; cursor: pointer; border-radius: theme('borderRadius.md'); transition: background-color 0.15s ease; overflow: hidden; border-left: 3px solid transparent; }
+.deck-item:hover { background-color: theme('colors.sidebar-item-hover'); }
+.deck-item.selected { background-color: theme('colors.sidebar-item-selected'); border-left: 3px solid theme('colors.baby-blue'); }
+.slide-icon { width: 32px; height: 32px; border-radius: theme('borderRadius.sm'); object-fit: cover; margin-right: 10px; border: 1px solid theme('colors.border'); flex-shrink: 0; background-color: #444; }
+.slide-name { flex-grow: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-size: 0.9em; color: theme('colors.text-off-white'); line-height: 1.4; }
+button.deck-save-btn { margin-left: 5px; background: none; border: none; color: theme('colors.text-off-white'); cursor: pointer; }
 
 /* Sidebar Collapse Arrow */
-#collapse-arrow { position: absolute; top: 8px; right: 8px; width: 24px; height: 24px; padding: 2px; cursor: pointer; fill: var(--text-grey); transition: transform 0.3s ease-in-out, right 0.3s ease-in-out, fill 0.2s ease; border-radius: 4px; }
-#collapse-arrow:hover { background-color: var(--sidebar-item-hover); fill: var(--text-off-white); }
+#collapse-arrow { position: absolute; top: 8px; right: 8px; width: 24px; height: 24px; padding: 2px; cursor: pointer; fill: theme('colors.text-grey'); transition: transform 0.3s ease-in-out, right 0.3s ease-in-out, fill 0.2s ease; border-radius: theme('borderRadius.sm'); }
+#collapse-arrow:hover { background-color: theme('colors.sidebar-item-hover'); fill: theme('colors.text-off-white'); }
 
 #app-title {
     margin: 10px;
     padding: 6px 8px;
-    color: var(--light-cyan);
+    color: theme('colors.light-cyan');
     font-size: 1.2em;
     font-weight: bold;
-    text-shadow: 0 0 10px var(--light-cyan);
-    border: 2px solid var(--light-cyan);
+    text-shadow: 0 0 10px theme('colors.light-cyan');
+    border: 2px solid theme('colors.light-cyan');
     border-radius: 6px;
 }
 
@@ -144,22 +120,22 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
 #left-sidebar.collapsed #create-slide,
 #left-sidebar.collapsed .slide-name,
 #left-sidebar.collapsed #create-deck { display: none; }
-#left-sidebar.collapsed #persona-section { padding: 5px; align-items: center; overflow-y: hidden; padding-bottom: 5px; border-bottom: 1px solid var(--separator-color); margin-bottom: 5px; }
+#left-sidebar.collapsed #persona-section { padding: 5px; align-items: center; overflow-y: hidden; padding-bottom: 5px; border-bottom: 1px solid theme('colors.separator'); margin-bottom: 5px; }
 #left-sidebar.collapsed .persona-item,
 #left-sidebar.collapsed .deck-item { padding: 6px 0px; margin-bottom: 4px; margin-right: 0; justify-content: center; border-left: none; width: 100%; }
-#left-sidebar.collapsed .persona-item.primary-persona.selected { background-color: var(--sidebar-item-selected); }
+#left-sidebar.collapsed .persona-item.primary-persona.selected { background-color: theme('colors.sidebar-item-selected'); }
 #left-sidebar.collapsed .persona-icon,
 #left-sidebar.collapsed .slide-icon { margin-right: 0; width: 30px; height: 30px; }
 #left-sidebar.collapsed #collapse-arrow { transform: rotate(180deg); right: auto; left: 13px; top: 6px; }
 
 /* --- Main Content Area --- */
-#main-content { background-color: var(--bg-very-dark); padding: 0; position: relative; overflow: hidden; display: flex; flex-direction: column; }
+#main-content { background-color: theme('colors.bg-very-dark'); padding: 0; position: relative; overflow: hidden; display: flex; flex-direction: column; }
 #central-display { width: 100%; display: flex; flex-direction: column; flex-grow: 1; overflow: hidden; }
 
 #persona-status-bar {
     width: 100%;
-    background-color: var(--sidebar-bg);
-    border-bottom: 1px solid var(--border-color);
+    background-color: theme('colors.sidebar-bg');
+    border-bottom: 1px solid theme('colors.border');
     position: relative;
     z-index: 10;
     transition: height 0.3s ease-in-out, padding 0.3s ease-in-out, transform 0.6s ease;
@@ -230,8 +206,8 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
     transition: opacity 0.1s ease-in-out;
 }
 
-#status-title { font-size: 1.2em; font-weight: bold; color: var(--text-off-white); white-space: nowrap; }
-#status-info { font-size: 0.9em; color: var(--text-grey); margin-top: 0; white-space: nowrap; }
+#status-title { font-size: 1.2em; font-weight: bold; color: theme('colors.text-off-white'); white-space: nowrap; }
+#status-info { font-size: 0.9em; color: theme('colors.text-grey'); margin-top: 0; white-space: nowrap; }
 #status-info span { margin-right: 15px; }
 
 #status-collapse-arrow {
@@ -241,7 +217,7 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
     width: 20px;
     height: 20px;
     cursor: pointer;
-    fill: var(--text-off-white);
+    fill: theme('colors.text-off-white');
     z-index: 12;
     transition: transform 0.3s ease-in-out, bottom 0.3s ease-in-out;
 }
@@ -258,8 +234,8 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
     position: relative;
     z-index: 5;
     transition: padding-top 0.3s ease-in-out;
-    scroll-padding-top: var(--scroll-padding, 10px);
-    scroll-padding-bottom: var(--scroll-padding, 10px);
+    scroll-padding-top: theme('spacing.scroll');
+    scroll-padding-bottom: theme('spacing.scroll');
 }
 
 #persona-status-bar.collapsed + #displays-container {
@@ -267,10 +243,10 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
 }
 
 .display-wrapper { width: 100%; position: relative; aspect-ratio: 16 / 9; margin-bottom: 10px; }
-.display { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background-color: #222; border: 1px solid var(--border-color); border-radius: 4px; overflow: hidden; display: flex; filter: brightness(35%); transition: filter 0.3s ease-in-out; }
+.display { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background-color: #222; border: 1px solid theme('colors.border'); border-radius: theme('borderRadius.sm'); overflow: hidden; display: flex; filter: brightness(35%); transition: filter 0.3s ease-in-out; }
 .display img, .display webview, .display iframe { border: none; display: none; width: 100%; height: 100%; min-height: 100%; flex-shrink: 0; object-fit: contain; background-color: #000; }
 .display img.active, .display webview.active, .display iframe.active { display: block; }
-.display .loading { position: absolute; top: 50%; left: 50%; width: 40px; height: 40px; border: 4px solid var(--text-grey); border-top: 4px solid var(--baby-blue); border-radius: 50%; animation: spin 1s linear infinite; transform: translate(-50%, -50%); display: none; z-index: 5; }
+.display .loading { position: absolute; top: 50%; left: 50%; width: 40px; height: 40px; border: 4px solid theme('colors.text-grey'); border-top: 4px solid theme('colors.baby-blue'); border-radius: 50%; animation: spin 1s linear infinite; transform: translate(-50%, -50%); display: none; z-index: 5; }
 .display.loading-active .loading { display: block; }
 @keyframes spin { 0% { transform: translate(-50%, -50%) rotate(0deg); } 100% { transform: translate(-50%, -50%) rotate(360deg); } }
 .bounce-in { animation: bounce-in 0.6s ease forwards; }
@@ -312,8 +288,8 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
 #program-maker.center-glow::after {
   content: '';
   position: absolute;
-  background: var(--display-highlight);
-  box-shadow: 0 0 12px 4px var(--display-highlight);
+  background: theme('colors.display-highlight');
+  box-shadow: 0 0 12px 4px theme('colors.display-highlight');
   pointer-events: none;
   z-index: 50;
   opacity: 1;
@@ -330,7 +306,7 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
   from { opacity: 1; }
   to { opacity: 0; }
 }
-.display-number { position: absolute; top: 5px; left: 5px; background-color: rgba(0, 0, 0, 0.7); color: var(--text-off-white); padding: 2px 5px; border-radius: 3px; font-size: 0.8em; z-index: 10; }
+.display-number { position: absolute; top: 5px; left: 5px; background-color: rgba(0, 0, 0, 0.7); color: theme('colors.text-off-white'); padding: 2px 5px; border-radius: 3px; font-size: 0.8em; z-index: 10; }
 .clear-button { position: absolute; top: 5px; right: 5px; width: 20px; height: 20px; background-color: rgba(255, 0, 0, 0.6); color: white; text-align: center; line-height: 20px; border-radius: 50%; cursor: pointer; font-size: 0.8em; font-weight: bold; z-index: 10; border: 1px solid rgba(255, 255, 255, 0.3); transition: background-color 0.2s ease; }
 .clear-button:hover { background-color: rgba(200, 0, 0, 0.8); }
 .program-icons {
@@ -348,14 +324,14 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
     align-items: center;
     justify-content: center;
     background-color: rgba(0,0,0,0.6);
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border: 1px solid theme('colors.border');
+    border-radius: theme('borderRadius.sm');
     cursor: pointer;
     font-size: 14px;
     user-select: none;
 }
 .program-icon:hover {
-    background-color: var(--sidebar-item-hover);
+    background-color: theme('colors.sidebar-item-hover');
 }
 
 /* Enlarged and centered when the display has no content */
@@ -410,8 +386,8 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
     width: 40px;
     height: 40px;
     flex: 0 0 auto;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border: 1px solid theme('colors.border');
+    border-radius: theme('borderRadius.sm');
     color: #fff;
     font-weight: 600;
     display: flex;
@@ -487,10 +463,10 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
     align-items: center;
     padding: 2px 4px;
     cursor: pointer;
-    border: 1px solid var(--border-color);
+    border: 1px solid theme('colors.border');
     border-bottom: none;
     border-radius: 4px 4px 0 0;
-    background-color: var(--bg-dark-grey);
+    background-color: theme('colors.bg-dark-grey');
     transition: background-color 0.15s ease;
     flex-shrink: 0;
 }
@@ -505,15 +481,15 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
     display: none;
 }
 
-.slide-tab:hover { background-color: var(--sidebar-item-hover); }
-.slide-tab.selected { background-color: var(--sidebar-item-selected); border-color: var(--sidebar-item-selected-border); }
+.slide-tab:hover { background-color: theme('colors.sidebar-item-hover'); }
+.slide-tab.selected { background-color: theme('colors.sidebar-item-selected'); border-color: theme('colors.baby-blue'); }
 
 /* --- Right Chat Panel --- */
 #right-chat {
-    background-color: var(--bg-dark-grey);
+    background-color: theme('colors.bg-dark-grey');
     padding: 0;
     height: 100vh;
-    border-left: 1px solid var(--border-color);
+    border-left: 1px solid theme('colors.border');
     transition: width 0.3s ease-in-out, transform 0.6s ease;
     width: 340px;
     position: relative;
@@ -527,52 +503,52 @@ button.deck-save-btn { margin-left: 5px; background: none; border: none; color: 
 #right-chat.collapsed #chat-log-container h2, #right-chat.collapsed #chat-log-container #chat-log, #right-chat.collapsed #chat-input-area { display: none; }
 #right-chat.collapsed #chat-collapse-arrow { transform: rotate(180deg); right: auto; left: 15px; }
 #chat-log-container { flex-grow: 1; display: flex; flex-direction: column; overflow: hidden; padding: 10px 15px 0 15px; position: relative; }
-#chat-log-container h2 { margin-bottom: 10px; flex-shrink: 0; border: none; padding-left: 0; padding-bottom: 5px; border-bottom: 1px solid var(--border-color); font-size: 0.75em; font-weight: 600; color: var(--text-grey); text-transform: uppercase; letter-spacing: 0.8px; }
+#chat-log-container h2 { margin-bottom: 10px; flex-shrink: 0; border: none; padding-left: 0; padding-bottom: 5px; border-bottom: 1px solid theme('colors.border'); font-size: 0.75em; font-weight: 600; color: theme('colors.text-grey'); text-transform: uppercase; letter-spacing: 0.8px; }
 #chat-log { flex-grow: 1; overflow-y: auto; padding-right: 5px; margin-bottom: 10px; line-height: 1.5; font-size: 0.9em; color: #ccc; }
 #chat-log p { margin-bottom: 10px; padding: 8px 12px; word-wrap: break-word; border-radius: 8px; max-width: 85%; }
 #chat-log p.user-message { background-color: #ADD8E6; color: #000000; margin-left: auto; margin-right: 0; }
-#chat-log p.ai-message { background-color: var(--sidebar-bg); color: var(--text-off-white); margin-right: auto; margin-left: 0; }
-#chat-log p.status-message { background-color: transparent; color: var(--text-grey); font-style: italic; text-align: center; font-size: 0.8em; margin-left: auto; margin-right: auto; padding: 4px 0; max-width: 100%; }
+#chat-log p.ai-message { background-color: theme('colors.sidebar-bg'); color: theme('colors.text-off-white'); margin-right: auto; margin-left: 0; }
+#chat-log p.status-message { background-color: transparent; color: theme('colors.text-grey'); font-style: italic; text-align: center; font-size: 0.8em; margin-left: auto; margin-right: auto; padding: 4px 0; max-width: 100%; }
 #chat-log p strong { margin-right: 5px; font-weight: 600; position: relative; display: block; margin-bottom: 3px; font-size: 0.8em; opacity: 0.8; }
 #chat-log p.user-message strong { display: none; }
-#chat-log p.ai-message strong { color: var(--baby-blue); }
+#chat-log p.ai-message strong { color: theme('colors.baby-blue'); }
 #chat-log p.ai-message.error-message strong { color: #FF6B6B; }
-#chat-log p.ai-message strong .thinking-bar { display: none; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background-color: var(--baby-blue); animation: thinking 1.5s linear infinite; }
+#chat-log p.ai-message strong .thinking-bar { display: none; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background-color: theme('colors.baby-blue'); animation: thinking 1.5s linear infinite; }
 #chat-log p.ai-message.thinking-active strong .thinking-bar { display: inline-block; }
 @keyframes thinking { 0% { width: 0; opacity: 0.5; } 50% { width: 100%; opacity: 1; } 100% { width: 0; opacity: 0.5; } }
-#chat-input-area { display: flex; padding: 15px; border-top: 1px solid var(--border-color); background-color: var(--sidebar-bg); flex-shrink: 0; }
-#chat-input-area input[type="text"] { flex-grow: 1; padding: 8px 10px; border: 1px solid #555; background-color: var(--input-bg); color: var(--text-off-white); border-radius: 4px; margin-right: 10px; font-size: 0.9em; }
-#chat-input-area input[type="text"]::placeholder { color: var(--text-dark-grey); }
-#chat-input-area button { padding: 8px 15px; border: none; background-color: var(--baby-blue); color: #111; border-radius: 4px; cursor: pointer; transition: background-color 0.2s ease; font-size: 0.9em; font-weight: 600; }
-#chat-input-area button:hover { background-color: var(--baby-blue-darker); }
-#chat-collapse-arrow { position: absolute; top: 8px; right: 8px; width: 24px; height: 24px; padding: 2px; cursor: pointer; fill: var(--text-grey); transition: transform 0.3s ease-in-out, left 0.3s ease-in-out, fill 0.2s ease; border-radius: 4px; z-index: 10; }
-#chat-collapse-arrow:hover { background-color: var(--sidebar-item-hover); fill: var(--text-off-white); }
+#chat-input-area { display: flex; padding: 15px; border-top: 1px solid theme('colors.border'); background-color: theme('colors.sidebar-bg'); flex-shrink: 0; }
+#chat-input-area input[type="text"] { flex-grow: 1; padding: 8px 10px; border: 1px solid #555; background-color: theme('colors.input-bg'); color: theme('colors.text-off-white'); border-radius: theme('borderRadius.sm'); margin-right: 10px; font-size: 0.9em; }
+#chat-input-area input[type="text"]::placeholder { color: theme('colors.text-dark-grey'); }
+#chat-input-area button { padding: 8px 15px; border: none; background-color: theme('colors.baby-blue'); color: #111; border-radius: theme('borderRadius.sm'); cursor: pointer; transition: background-color 0.2s ease; font-size: 0.9em; font-weight: 600; }
+#chat-input-area button:hover { background-color: theme('colors.baby-blue-darker'); }
+#chat-collapse-arrow { position: absolute; top: 8px; right: 8px; width: 24px; height: 24px; padding: 2px; cursor: pointer; fill: theme('colors.text-grey'); transition: transform 0.3s ease-in-out, left 0.3s ease-in-out, fill 0.2s ease; border-radius: theme('borderRadius.sm'); z-index: 10; }
+#chat-collapse-arrow:hover { background-color: theme('colors.sidebar-item-hover'); fill: theme('colors.text-off-white'); }
 
 
 /* --- Config Panel --- */
 #info-panels {
     position: relative;
     margin-top: 10px;
-    background-color: var(--bg-dark-grey);
-    border-top: 1px solid var(--border-color);
+    background-color: theme('colors.bg-dark-grey');
+    border-top: 1px solid theme('colors.border');
     box-shadow: 0 0 10px rgba(0,0,0,0.8);
     transition: height 0.3s ease-in-out, padding 0.3s ease-in-out, transform 0.6s ease;
     transform-origin: bottom center;
 }
-#config-header { background-color: var(--sidebar-bg); padding: 10px; cursor: pointer; font-size: 0.9em; color: var(--text-off-white); text-align: center; border-bottom: 1px solid var(--border-color); transition: background-color 0.2s ease; }
+#config-header { background-color: theme('colors.sidebar-bg'); padding: 10px; cursor: pointer; font-size: 0.9em; color: theme('colors.text-off-white'); text-align: center; border-bottom: 1px solid theme('colors.border'); transition: background-color 0.2s ease; }
 #info-panels.active #config-header { border-bottom: none; }
 #config-header:hover { background-color: rgba(135, 206, 250, 0.1); }
-#config-content { max-height: 0; overflow: hidden; padding: 0 15px; transition: max-height 0.3s ease-in-out, padding 0.1s ease-in-out; background-color: var(--sidebar-bg); }
+#config-content { max-height: 0; overflow: hidden; padding: 0 15px; transition: max-height 0.3s ease-in-out, padding 0.1s ease-in-out; background-color: theme('colors.sidebar-bg'); }
 #info-panels.active #config-content { max-height: none; padding: 15px; overflow: visible; }
 .dropdown { margin-bottom: 10px; }
-.dropdown-header { background-color: var(--bg-dark-grey); padding: 10px; cursor: pointer; border: 1px solid var(--border-color); border-radius: 4px; font-size: 0.9em; color: var(--text-off-white); transition: background-color 0.2s ease; }
+.dropdown-header { background-color: theme('colors.bg-dark-grey'); padding: 10px; cursor: pointer; border: 1px solid theme('colors.border'); border-radius: theme('borderRadius.sm'); font-size: 0.9em; color: theme('colors.text-off-white'); transition: background-color 0.2s ease; }
 .dropdown-header:hover { background-color: rgba(135, 206, 250, 0.1); }
-.dropdown-content { max-height: 0; overflow: hidden; padding: 0 10px; background-color: var(--input-bg); border: 1px solid var(--border-color); border-top: none; border-radius: 0 0 4px 4px; transition: max-height 0.3s ease-in-out, padding 0.1s ease-in-out; }
+.dropdown-content { max-height: 0; overflow: hidden; padding: 0 10px; background-color: theme('colors.input-bg'); border: 1px solid theme('colors.border'); border-top: none; border-radius: 0 0 4px 4px; transition: max-height 0.3s ease-in-out, padding 0.1s ease-in-out; }
 .dropdown-content.active { max-height: none; padding: 10px; overflow: visible; }
-textarea { width: 100%; min-height: 100px; background-color: var(--bg-very-dark); color: var(--text-off-white); border: 1px solid #555; padding: 8px; font-size: 0.9em; resize: vertical; border-radius: 4px; overflow-y: hidden; }
+textarea { width: 100%; min-height: 100px; background-color: theme('colors.bg-very-dark'); color: theme('colors.text-off-white'); border: 1px solid #555; padding: 8px; font-size: 0.9em; resize: vertical; border-radius: theme('borderRadius.sm'); overflow-y: hidden; }
 .dropdown-buttons { margin-top: 10px; display: flex; justify-content: flex-end; }
-.dropdown-buttons button { padding: 8px 15px; border: none; background-color: var(--baby-blue); color: #111; border-radius: 4px; cursor: pointer; margin-left: 10px; font-size: 0.9em; font-weight: 600; transition: background-color 0.2s ease; }
-.dropdown-buttons button:hover { background-color: var(--baby-blue-darker); }
+.dropdown-buttons button { padding: 8px 15px; border: none; background-color: theme('colors.baby-blue'); color: #111; border-radius: theme('borderRadius.sm'); cursor: pointer; margin-left: 10px; font-size: 0.9em; font-weight: 600; transition: background-color 0.2s ease; }
+.dropdown-buttons button:hover { background-color: theme('colors.baby-blue-darker'); }
 #info-panels.primary-selected #auto-pre-prompt, #info-panels.primary-selected #update-memory { display: none; }
 #info-panels.primary-selected #memory-prompt-header, #info-panels.primary-selected #memory-prompt-content, #info-panels.primary-selected #memory-header, #info-panels.primary-selected #memory-content { display: none; }
 
@@ -582,8 +558,8 @@ textarea { width: 100%; min-height: 100px; background-color: var(--bg-very-dark)
     left: 0;
     right: 0;
     padding: 10px;
-    background-color: var(--bg-dark-grey);
-    border-top: 1px solid var(--border-color);
+    background-color: theme('colors.bg-dark-grey');
+    border-top: 1px solid theme('colors.border');
     box-shadow: 0 0 10px rgba(0,0,0,0.8);
     z-index: 10;
     transition: max-height 0.3s ease-in-out, padding 0.3s ease-in-out;
@@ -611,18 +587,18 @@ textarea { width: 100%; min-height: 100px; background-color: var(--bg-very-dark)
 #program-maker textarea {
     width: 100%;
     min-height: 60px;
-    background-color: var(--bg-very-dark);
-    color: var(--text-off-white);
+    background-color: theme('colors.bg-very-dark');
+    color: theme('colors.text-off-white');
     border: 1px solid #555;
     padding: 8px;
-    border-radius: 4px;
+    border-radius: theme('borderRadius.sm');
     resize: vertical;
     margin-bottom: 10px;
 }
 #program-output {
-    background-color: var(--bg-very-dark);
-    color: var(--text-off-white);
-    border: 1px solid var(--border-color);
+    background-color: theme('colors.bg-very-dark');
+    color: theme('colors.text-off-white');
+    border: 1px solid theme('colors.border');
     padding: 10px;
     max-height: 200px;
     overflow-y: auto;
@@ -632,10 +608,10 @@ textarea { width: 100%; min-height: 100px; background-color: var(--bg-very-dark)
 
 /* --- Global Scrollbar Styles --- */
 ::-webkit-scrollbar { width: 8px; height: 8px; }
-::-webkit-scrollbar-track { background: var(--sidebar-bg); border-radius: 4px; }
-::-webkit-scrollbar-thumb { background: #444; border-radius: 4px; border: 1px solid var(--sidebar-bg); }
+::-webkit-scrollbar-track { background: theme('colors.sidebar-bg'); border-radius: theme('borderRadius.sm'); }
+::-webkit-scrollbar-thumb { background: #444; border-radius: theme('borderRadius.sm'); border: 1px solid theme('colors.sidebar-bg'); }
 ::-webkit-scrollbar-thumb:hover { background: #666; }
-#persona-section, #displays-container, #chat-log, #config-content, #deck-icons, .dropdown-content { scrollbar-width: thin; scrollbar-color: #444 var(--sidebar-bg); }
+#persona-section, #displays-container, #chat-log, #config-content, #deck-icons, .dropdown-content { scrollbar-width: thin; scrollbar-color: #444 theme('colors.sidebar-bg'); }
 
 /* --- Login Overlay Styles --- */
 #login-overlay {
@@ -651,11 +627,11 @@ textarea { width: 100%; min-height: 100px; background-color: var(--bg-very-dark)
 #login-overlay.active { pointer-events: all; }
 #login-form {
     position: relative;
-    background: linear-gradient(to bottom, var(--bg-dark-grey), #222);
+    background: linear-gradient(to bottom, theme('colors.bg-dark-grey'), #222);
     padding: 25px;
-    border-radius: 10px;
-    border: 2px solid var(--baby-blue);
-    box-shadow: 0 0 20px var(--baby-blue);
+    border-radius: theme('borderRadius.lg');
+    border: 2px solid theme('colors.baby-blue');
+    box-shadow: 0 0 20px theme('colors.baby-blue');
     display: flex;
     flex-direction: column;
     gap: 15px;
@@ -664,28 +640,28 @@ textarea { width: 100%; min-height: 100px; background-color: var(--bg-very-dark)
 #login-form h1 {
     margin: 0 0 10px;
     text-align: center;
-    color: var(--baby-blue);
+    color: theme('colors.baby-blue');
     font-size: 1.6em;
-    text-shadow: 0 0 10px var(--baby-blue);
+    text-shadow: 0 0 10px theme('colors.baby-blue');
 }
 #login-form input {
     padding: 8px;
-    border-radius: 4px;
-    border: 1px solid var(--border-color);
-    background: var(--input-bg);
-    color: var(--text-off-white);
+    border-radius: theme('borderRadius.sm');
+    border: 1px solid theme('colors.border');
+    background: theme('colors.input-bg');
+    color: theme('colors.text-off-white');
 }
 #login-form button {
     padding: 8px 15px;
     border: none;
-    background: var(--baby-blue);
+    background: theme('colors.baby-blue');
     color: #111;
-    border-radius: 4px;
+    border-radius: theme('borderRadius.sm');
     cursor: pointer;
     font-weight: 600;
-    box-shadow: 0 0 10px var(--baby-blue);
+    box-shadow: 0 0 10px theme('colors.baby-blue');
 }
-#login-form button:hover { background: var(--baby-blue-darker); }
+#login-form button:hover { background: theme('colors.baby-blue-darker'); }
 #login-overlay.hidden { display: none; }
 
 body.pre-login .app-container {
@@ -713,8 +689,8 @@ body.pre-login #right-chat::before {
     top: 0;
     width: 2px;
     height: 100%;
-    background: var(--display-highlight);
-    box-shadow: 0 0 12px 4px var(--display-highlight);
+    background: theme('colors.display-highlight');
+    box-shadow: 0 0 12px 4px theme('colors.display-highlight');
     pointer-events: none;
     z-index: 50;
 }
@@ -763,7 +739,7 @@ body.logging-in #info-panels {
 /* Highlight displays that are fully visible */
 .display.fully-visible {
     filter: brightness(100%);
-    border-color: var(--border-color);
+    border-color: theme('colors.border');
     box-shadow: none;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,41 @@
+module.exports = {
+  content: ["./index.html", "./**/*.js"],
+  theme: {
+    extend: {
+      colors: {
+        'sidebar-bg': '#1f1f23',
+        'sidebar-item-hover': 'rgba(135, 206, 250, 0.1)',
+        'sidebar-item-selected': 'rgba(135, 206, 250, 0.2)',
+        'baby-blue': '#87CEFA',
+        'baby-blue-darker': '#6495ED',
+        'bg-very-dark': '#0e0e10',
+        'bg-dark-grey': '#18181b',
+        'text-off-white': '#efeff1',
+        'text-grey': '#adadb8',
+        'text-dark-grey': '#888',
+        'border': '#444',
+        'separator': '#3a3a3d',
+        'input-bg': '#3a3a3d',
+        'button-text-dark': '#111',
+        'user-green': '#7FFFD4',
+        'light-cyan': '#e0ffff',
+        'display-highlight': 'rgba(255,165,0,0.6)'
+      },
+      spacing: {
+        'scroll': '10px',
+        'primary-icon': '38px',
+        'primary-item-x': '10px',
+        'primary-item-y': '8px'
+      },
+      fontSize: {
+        'primary': '0.95em'
+      },
+      borderRadius: {
+        'sm': '4px',
+        'md': '5px',
+        'lg': '10px'
+      }
+    }
+  },
+  plugins: []
+};


### PR DESCRIPTION
## Summary
- add Tailwind configuration with color, spacing, typography, and radius tokens
- refactor stylesheet to use Tailwind theme tokens and remove custom properties

## Testing
- `npm test` *(fails: jest not found; package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688d96834f10832394ac4c2b68139e10