### PR TITLE
Expand window top bar across full width

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body class="pre-login">
+    <div id="title-bar"></div>
     <div id="login-overlay">
         <form id="login-form">
             <h1 id="login-title">Your Personal Ai Vault</h1>

--- a/main.js
+++ b/main.js
@@ -161,7 +161,7 @@ async function launchBrowser() {
         show: false,
         autoHideMenuBar: true,
         titleBarStyle: 'hidden',
-        titleBarOverlay: { color: '#333333', symbolColor: '#ffffff' },
+        titleBarOverlay: { color: '#333333', symbolColor: '#ffffff', height: 30 },
     });
     browserWindow.removeMenu();
 
@@ -291,7 +291,7 @@ async function createWindow(serverUrl) {
         show: false,
         autoHideMenuBar: true,
         titleBarStyle: 'hidden',
-        titleBarOverlay: { color: '#333333', symbolColor: '#ffffff' },
+        titleBarOverlay: { color: '#333333', symbolColor: '#ffffff', height: 30 },
     });
     mainWindow.removeMenu();
 

--- a/style.css
+++ b/style.css
@@ -46,13 +46,24 @@
     --primary-item-padding: var(--space-2) var(--space-3);
     --primary-font-size: var(--font-size-md);
     --display-highlight: rgba(255, 165, 0, 0.6);
+    --title-bar-height: 30px;
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
 body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background-color: var(--bg-very-dark); color: var(--text-off-white); height: 100vh; overflow: hidden; }
 
-.app-container { display: grid; grid-template-columns: minmax(50px, 260px) 1fr minmax(50px, 340px); grid-template-rows: 1fr; height: 100vh; background-color: var(--bg-dark-grey); gap: 1px; background-color: var(--border-color); transition: grid-template-columns 0.3s ease-in-out; }
+#title-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: var(--title-bar-height);
+    background-color: #333333;
+    -webkit-app-region: drag;
+    z-index: 10000;
+}
+.app-container { display: grid; grid-template-columns: minmax(50px, 260px) 1fr minmax(50px, 340px); grid-template-rows: 1fr; height: calc(100vh - var(--title-bar-height)); margin-top: var(--title-bar-height); background-color: var(--bg-dark-grey); gap: 1px; background-color: var(--border-color); transition: grid-template-columns 0.3s ease-in-out; }
 .app-container.collapsed { grid-template-columns: 50px 1fr minmax(50px, 340px); }
 .app-container.chat-collapsed { grid-template-columns: minmax(50px, 260px) 1fr 50px; }
 .app-container.collapsed.chat-collapsed { grid-template-columns: 50px 1fr 50px; }


### PR DESCRIPTION
## Summary
- add fixed, full-width `#title-bar` element for window dragging
- offset application layout to sit below new bar
- specify `titleBarOverlay` height for Electron windows

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: Cannot find module 'extract-zip')*

------
https://chatgpt.com/codex/tasks/task_e_688f4edf35a08323bb1c3334a5c739d7