### PR TITLE
style: integrate title bar with app theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -59,9 +59,10 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helve
     left: 0;
     width: 100%;
     height: var(--title-bar-height);
-    background-color: #333333;
+    background-color: var(--bg-dark-grey);
+    border-bottom: 1px solid var(--border-color);
     -webkit-app-region: drag;
-    z-index: 10000;
+    z-index: 100;
 }
 .app-container { display: grid; grid-template-columns: minmax(50px, 260px) 1fr minmax(50px, 340px); grid-template-rows: 1fr; height: calc(100vh - var(--title-bar-height)); margin-top: var(--title-bar-height); background-color: var(--bg-dark-grey); gap: 1px; background-color: var(--border-color); transition: grid-template-columns 0.3s ease-in-out; }
 .app-container.collapsed { grid-template-columns: 50px 1fr minmax(50px, 340px); }


### PR DESCRIPTION
## Summary
- blend title bar with app styling using theme colors and border
- lower title bar z-index so overlays like login screen can cover it

## Testing
- `npm test` *(fails: jest not found after dependency install attempt)*

------
https://chatgpt.com/codex/tasks/task_e_688f515261cc832388ca6ae022dfe44c