### PR TITLE
fix: keep window controls inside title bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,6 +54,10 @@
 body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background-color: var(--bg-very-dark); color: var(--text-off-white); height: 100vh; overflow: hidden; }
 
 #title-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
     width: 100%;
     height: var(--title-bar-height);
     background-color: var(--bg-dark-grey);
@@ -92,6 +96,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helve
     grid-template-columns: minmax(50px, 260px) 1fr minmax(50px, 340px);
     grid-template-rows: 1fr;
     height: calc(100vh - var(--title-bar-height));
+    margin-top: var(--title-bar-height);
     background-color: var(--bg-dark-grey);
     gap: 1px;
     background-color: var(--border-color);


### PR DESCRIPTION
## Summary
- Keep custom Electron window controls anchored inside the fixed title bar
- Offset app layout to account for the fixed title bar height

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: Cannot find module 'extract-zip')*


------
https://chatgpt.com/codex/tasks/task_e_688f5dcff4c88323880d877cf3a57cc8