### PR TITLE
fix: restore open displays on startup

### DIFF
--- a/ipcHandlers.js
+++ b/ipcHandlers.js
@@ -350,16 +350,8 @@ function initialize(windowInstance, paths) {
         }
     });
 
-    sharedDataService.getOpenDisplays()
-        .then(displays => {
-            sendToRenderer('restore-open-displays', displays);
-        })
-        .catch(err => {
-            console.error('IPC: Failed to load open displays:', err);
-        })
-        .finally(() => {
-            sendToRenderer('backend-ready');
-        });
+    // Notify the renderer once backend initialization is complete
+    sendToRenderer('backend-ready');
 }
 
 module.exports = initialize;

--- a/main.js
+++ b/main.js
@@ -735,7 +735,8 @@ app.whenReady().then(async () => {
         try {
             const savedDisplays = await sharedDataService.getOpenDisplays();
             console.log('>>> Restoring saved displays:', savedDisplays);
-            // The restoration will be handled by the renderer after backend-ready signal
+            // Proactively send saved display information to the renderer
+            sendToRenderer('restore-open-displays', savedDisplays);
         } catch (error) {
             console.error('Failed to load saved displays:', error);
         }

--- a/renderer.js
+++ b/renderer.js
@@ -818,12 +818,7 @@ function setupIpcListeners() {
         await fetchFavoritePersona();
         console.log("Renderer: Requesting persona list...");
         window.electronAPI.send('discover-personas');
-        try {
-            const displays = await window.electronAPI.invoke('get-open-displays');
-            restoreOpenDisplays(displays);
-        } catch (err) {
-            console.error('Renderer: Failed to retrieve open displays:', err);
-        }
+        // Display restoration is now handled by a dedicated event from the main process
     });
     window.electronAPI.on('restore-open-displays', (displays) => {
         restoreOpenDisplays(displays);


### PR DESCRIPTION
## Summary
- send saved display state to renderer on launch
- streamline backend initialization to emit only `backend-ready`
- rely on `restore-open-displays` event for display recovery

## Testing
- `npm test` *(fails: jest: not found)*
- `node test-persistence.js` *(fails: no such file or directory, sharedData.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fd046cbe08323ad9aa0c88a91f21f