### PR TITLE
fix: restore programs from saved state

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -818,7 +818,12 @@ function setupIpcListeners() {
         await fetchFavoritePersona();
         console.log("Renderer: Requesting persona list...");
         window.electronAPI.send('discover-personas');
-        // Display restoration is now handled by a dedicated event from the main process
+        try {
+            const displays = await window.electronAPI.invoke('get-open-displays');
+            restoreOpenDisplays(displays);
+        } catch (err) {
+            console.error('Renderer: Failed to restore displays:', err);
+        }
     });
     window.electronAPI.on('restore-open-displays', (displays) => {
         restoreOpenDisplays(displays);


### PR DESCRIPTION
## Summary
- Request open displays from backend when signaled ready and restore them in the renderer

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: Cannot find module 'extract-zip')*


------
https://chatgpt.com/codex/tasks/task_e_688fd950ab8c8323891fbb6b85b0c5cd