### PR TITLE
ensure display programs persist across app restarts

### DIFF
--- a/main.js
+++ b/main.js
@@ -776,6 +776,7 @@ app.on('before-quit', async () => {
         const existing = await sharedDataService.getOpenDisplays();
         const memory = gatherOpenDisplayState();
         await sharedDataService.setOpenDisplays({ ...existing, ...memory });
+        await sharedDataService.flushWrites();
     } catch (err) {
         console.error('Main: Failed to persist open display state on before-quit:', err);
     }
@@ -791,6 +792,7 @@ app.on('will-quit', async () => {
         const existing = await sharedDataService.getOpenDisplays();
         const memory = gatherOpenDisplayState();
         await sharedDataService.setOpenDisplays({ ...existing, ...memory });
+        await sharedDataService.flushWrites();
     } catch (err) {
         console.error('Main: Failed to persist open display state on quit:', err);
     }


### PR DESCRIPTION
## Summary
- cache shared data in memory and add flush helper to avoid losing pending writes
- flush queued writes during Electron shutdown to reliably persist open display state

## Testing
- `npm test` *(fails: jest not found)*
- `node test-persistence.js`
- `node test-enhanced-persistence.js` *(fails: Multi-Tab URL Storage, Active Tab Index Tracking, Timestamp Tracking)*

------
https://chatgpt.com/codex/tasks/task_e_688fe062bf348323888939e1be4ee948