### PR TITLE
fix: ensure persisted displays reopen

### DIFF
--- a/__tests__/openProgram.test.js
+++ b/__tests__/openProgram.test.js
@@ -72,4 +72,19 @@ describe('open-program handler', () => {
       true
     );
   });
+
+  test('uses provided serverUrl when constructing program URL', async () => {
+    fs.access = jest.fn().mockResolvedValue();
+    mockWindow.webContents.send.mockClear();
+    initialize(mockWindow, { serverUrl: 'http://localhost:4000', userDataPath: '/tmp' });
+    const handler = handlers['open-program'];
+    await handler({}, { program: 'test', displayId: 'display1' });
+    expect(mockWindow.webContents.send).toHaveBeenCalledWith(
+      'load-display',
+      expect.objectContaining({
+        displayId: 'display1',
+        url: 'http://localhost:4000/programs/test/index.html'
+      })
+    );
+  });
 });

--- a/main.js
+++ b/main.js
@@ -318,7 +318,16 @@ async function createWindow(serverUrl) {
     });
 
     // Initialize your existing IPC handlers
-    initializeIpcHandlers(mainWindow, { vaultPath, decksPath, userDataPath, dataDir, imagesPath, videosPath, calendarPath });
+    initializeIpcHandlers(mainWindow, {
+        vaultPath,
+        decksPath,
+        userDataPath,
+        dataDir,
+        imagesPath,
+        videosPath,
+        calendarPath,
+        serverUrl
+    });
 
     
 ipcMain.on('add-adblock-patterns', (event, patterns) => {


### PR DESCRIPTION
## Summary
- pass local server URL into IPC handler initialization so restored programs load on correct port
- test that `open-program` honors provided serverUrl when constructing program paths

## Testing
- `npm install` *(fails: E403 403 Forbidden - GET https://registry.npmjs.org/electron-builder)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ff4c29da483239bba229b7510909f