### PR TITLE
feat: add persona tiered memory fields

### DIFF
--- a/__tests__/personaService.test.js
+++ b/__tests__/personaService.test.js
@@ -3,7 +3,10 @@ const os = require('os');
 const path = require('path');
 const {
   sanitizeFolderName,
-  savePersonaFileContent
+  savePersonaFileContent,
+  loadPersonaData,
+  savePersonaData,
+  discoverPersonas
 } = require('../personaService');
 
 describe('personaService utilities', () => {
@@ -20,6 +23,46 @@ describe('personaService utilities', () => {
     const filePath = path.join(tmpDir, sanitizeFolderName(identifier), fileName);
     const saved = await fs.readFile(filePath, 'utf-8');
     expect(saved).toBe(content);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('loadPersonaData returns defaults when file missing', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'persona-'));
+    const data = await loadPersonaData('Missing Persona', tmpDir);
+    expect(data).toEqual({
+      shortTermHistory: [],
+      midTermSlots: [],
+      longTermStore: { items: [] }
+    });
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('savePersonaData persists data', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'persona-'));
+    const identifier = 'Persist Persona';
+    const sample = {
+      shortTermHistory: [{ role: 'user', content: 'hi', ts: 1 }],
+      midTermSlots: [{ summary: 'test', embedding: [0.1], priority: 1, ts: 1 }],
+      longTermStore: { items: [{ id: '1', summary: 'long', embedding: [0.2], meta: {} }] }
+    };
+    await savePersonaData(identifier, sample, tmpDir);
+    const loaded = await loadPersonaData(identifier, tmpDir);
+    expect(loaded).toEqual(sample);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('discoverPersonas includes memory fields', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'persona-'));
+    const baseDir = tmpDir;
+    await fs.mkdir(path.join(baseDir, 'images'), { recursive: true });
+    await fs.writeFile(path.join(baseDir, 'images', 'test_persona.png'), '');
+    const identifier = 'Test Persona';
+    const personaDir = path.join(tmpDir, sanitizeFolderName(identifier));
+    await fs.mkdir(personaDir, { recursive: true });
+    await savePersonaData(identifier, { shortTermHistory: [], midTermSlots: [], longTermStore: { items: [] } }, tmpDir);
+    const personas = await discoverPersonas(tmpDir, baseDir);
+    expect(personas[0]).toHaveProperty('shortTermHistory');
+    expect(Array.isArray(personas[0].shortTermHistory)).toBe(true);
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- add load/save of tiered memory data for personas
- include memory fields when discovering personas
- test persona memory persistence and defaults

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: Error: Cannot find module 'extract-zip')*


------
https://chatgpt.com/codex/tasks/task_e_68915e02da488323b9ddbd0e0cd68ed7